### PR TITLE
Use dark theme when running dark highcontrast

### DIFF
--- a/src/MarkwhenTimelineEditorProvider.ts
+++ b/src/MarkwhenTimelineEditorProvider.ts
@@ -261,7 +261,7 @@ export class MarkwhenTimelineEditorProvider
 
   getAppState(): AppState {
     const isDark =
-      vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark;
+      [vscode.ColorThemeKind.Dark, vscode.ColorThemeKind.HighContrast].indexOf(vscode.window.activeColorTheme.kind) >= 0;
     return {
       isDark,
       hoveringPath: undefined,


### PR DESCRIPTION
https://vscode-api.js.org/enums/vscode.ColorThemeKind.html

`Dark` and `HighContrast` are both dark themes, this PR makes sure that dark high contrast also uses the Markwhen dark theme. 